### PR TITLE
Installation update, allow for 'malloc' storage backend

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,7 +1,7 @@
 default['varnish']['packages'] = %w(varnish)
 
 # NOTE: see http://repo.varnish-cache.org/source/ for versions
-default['varnish']['version'] = '4.1.3'
+default['varnish']['version'] = '5.1.2'
 
 default['varnish']['binary_path'] = '/usr/local/sbin/varnishd'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,8 +19,9 @@ default['varnish']['backend']['port'] = '8080'
 default['varnish']['admin']['ip']   = '127.0.0.1'
 default['varnish']['admin']['port'] = '6082'
 
-default['varnish']['cache']['file'] = '/var/lib/varnish/varnish_storage.bin'
-default['varnish']['cache']['size'] = '200M'
+default['varnish']['cache']['storage_backend'] = 'file'
+default['varnish']['cache']['file']            = '/var/lib/varnish/varnish_storage.bin'
+default['varnish']['cache']['size']            = '200M'
 
 default['varnish']['purge'] = {
     "localhost" => '',

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
 description 'Installs and configures varnish.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.6'
+version '2.0.0'
 
 source_url 'https://github.com/copious-cookbooks/varnish'
 issues_url 'https://github.com/copious-cookbooks/varnish/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,8 +10,8 @@ source_url 'https://github.com/copious-cookbooks/varnish'
 issues_url 'https://github.com/copious-cookbooks/varnish/issues'
 
 supports 'ubuntu', '>= 14.04'
-supports 'debian', '>= 6'
-supports 'rhel', '>= 6'
-supports 'centos', '>= 6'
+supports 'debian', '>= 8'
+supports 'rhel', '>= 7'
+supports 'centos', '>= 7'
 
 depends 'cop_base'

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -6,8 +6,6 @@
 
 include_recipe 'cop_base::dependencies'
 
-node['varnish']['dependencies'].each do |p|
-    package p do
-        action :install
-    end
+package node['varnish']['dependencies'] do
+    action :install
 end

--- a/templates/default/varnish.params.erb
+++ b/templates/default/varnish.params.erb
@@ -24,7 +24,12 @@ VARNISH_SECRET_FILE=/etc/varnish/secret
 #
 # NOTE: Cache file size: in bytes, optionally using k / M / G / T suffix,
 # or in percentage of available disk space using the % suffix.
+
+<% if node['varnish']['cache']['storage_backend'] == 'malloc' %>
+VARNISH_STORAGE="malloc,<%= node['varnish']['cache']['size'] %>"
+<% else %>
 VARNISH_STORAGE="file,<%= node['varnish']['cache']['file'] %>,<%= node['varnish']['cache']['size'] %>"
+<% end %>
 
 # Default TTL used when the backend does not specify one
 VARNISH_TTL=120


### PR DESCRIPTION
Condenses package installation, modifies template to allow for `malloc` storage backend. Does not include option for `persistent` storage backend as this is experimental and on the roadmap for deprecation.

Removes support for Debian < 8 and RHEL < 7