### PR TITLE
Update template to allow arbitrary URL bypass rules

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,3 +17,8 @@ suites:
   - name: default
     run_list:
       - recipe[cop_varnish::default]
+    attributes:
+      varnish:
+        bypass_url:
+          test1: "/test1/regex.url"
+          test2: "/test2/regex.url"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,6 +19,6 @@ suites:
       - recipe[cop_varnish::default]
     attributes:
       varnish:
-        bypass_url:
+        bypass_urls:
           test1: "/test1/regex.url"
           test2: "/test2/regex.url"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This cookbook will install and configure Varnish, a high-performance HTTP accele
 * `default['varnish']['cache']['file'] = '...'` The file Varnish will save data to. You shouldn't need to change this.
 * `default['varnish']['cache']['size'] = '200M'` The size limit of the Varnish cache file. Increase to save more data. Use a string in bytes, optionally using k / M / G / T suffix.
 * `default['varnish']['purge'] = { '192.168.0.0' => '/24' }` A list of addresses to allow purging Varnish cache. This should be an array of keys. If a network doesnt have a netmask, leave it empty.
+* `default['varnish']['bypass_urls'] = {}` Hash of URLs for which to bypass caching
 
 ## Usage
 Including the `cop_varnish` cookbook in the run_list ensures that varnish

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,8 @@ default['varnish']['purge'] = {
     "localhost" => '',
 }
 
+default['varnish']['bypass_url'] = {}
+
 case node['platform_family']
 when 'debian'
     default['varnish']['dependencies'] = %w(

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,7 +27,7 @@ default['varnish']['purge'] = {
     "localhost" => '',
 }
 
-default['varnish']['bypass_url'] = {}
+default['varnish']['bypass_urls'] = {}
 
 case node['platform_family']
 when 'debian'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
 description 'Installs and configures varnish.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.0.1'
+version '2.1.0'
 
 source_url 'https://github.com/copious-cookbooks/varnish'
 issues_url 'https://github.com/copious-cookbooks/varnish/issues'

--- a/templates/default/default.vcl.erb
+++ b/templates/default/default.vcl.erb
@@ -48,6 +48,13 @@ sub vcl_recv {
         return (pass);
     }
 
+<% node['varnish']['bypass_url'].each do |name,url| -%>
+    # Bypass <%= name %> at "<%= url %>"
+    if (req.url ~ "<%= url %>") {
+        return (pass);
+    }
+
+<% end -%>
     # normalize url in case of leading HTTP scheme and domain
     set req.url = regsub(req.url, "^http[s]?://", "");
 

--- a/templates/default/default.vcl.erb
+++ b/templates/default/default.vcl.erb
@@ -48,7 +48,7 @@ sub vcl_recv {
         return (pass);
     }
 
-<% node['varnish']['bypass_url'].each do |name,url| -%>
+<% node['varnish']['bypass_urls'].each do |name,url| -%>
     # Bypass <%= name %> at "<%= url %>"
     if (req.url ~ "<%= url %>") {
         return (pass);

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -9,7 +9,7 @@ describe 'cop_varnish::default' do
   end
 
   describe command('/usr/local/sbin/varnishd -V') do
-    its(:stderr) { should match /4.1.3/ }
+    its(:stderr) { should match /5.1.2/ }
   end
 
   describe file('/etc/varnish/secret') do

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -12,13 +12,6 @@ describe 'cop_varnish::default' do
     its(:stderr) { should match /4.1.3/ }
   end
 
-  describe file('/etc/varnish/default.vcl') do
-    it { should be_file }
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
-    it { should be_mode '644' }
-  end
-
   describe file('/etc/varnish/secret') do
     it { should be_file }
     it { should be_owned_by 'root' }
@@ -45,5 +38,16 @@ describe 'cop_varnish::default' do
   # varnish admin
   describe port(6082) do
     it { should be_listening.with('tcp') }
+  end
+end
+
+describe 'cop_varnish::vcl' do
+  describe file('/etc/varnish/default.vcl') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode '644' }
+    its(:content) { should include 'if (req.url ~ "/test1/regex.url")' }
+    its(:content) { should include 'if (req.url ~ "/test2/regex.url")' }
   end
 end


### PR DESCRIPTION
Updates the template to allow an attribute `node['varnish']['bypass_urls']` to be set which will then create Varnish rules to bypass certain URL patterns with the following format:

```
node['varnish']['bypass_urls'] = {
    test1: "/test1/regex.url",
    test2: "/test2/regex.url"
}
```
```
    # Bypass test1 at "/test1/regex.url"
    if (req.url ~ "/test1/regex.url") {
        return (pass);
    }

    # Bypass test2 at "/test2/regex.url"
    if (req.url ~ "/test2/regex.url") {
        return (pass);
    }
```