### PR TITLE
Bypass Cookie / Really Really Really Really Purge

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,9 @@ default['varnish']['cache']['storage_backend'] = 'file'
 default['varnish']['cache']['file']            = '/var/lib/varnish/varnish_storage.bin'
 default['varnish']['cache']['size']            = '200M'
 
+# Set this cookie to bypass Varnish cache
+default['varnish']['bypass_cookie'] = 'no_cache'
+
 default['varnish']['purge'] = {
     "localhost" => '',
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
 description 'Installs and configures varnish.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.1.0'
+version '2.2.0'
 
 source_url 'https://github.com/copious-cookbooks/varnish'
 issues_url 'https://github.com/copious-cookbooks/varnish/issues'

--- a/templates/default/default.vcl.erb
+++ b/templates/default/default.vcl.erb
@@ -82,7 +82,7 @@ sub vcl_recv {
     set req.url = regsuball(req.url,"&gclid=[^&]+",""); # strips when QS = "?foo=bar&gclid=AAA" or QS = "?foo=bar&gclid=AAA&bar=baz"
 
     # static files are always cacheable. remove SSL flag and cookie
-        if (req.url ~ "^/(pub/)?(media|static)/.*\.(ico|css|js|jpg|jpeg|png|gif|tiff|bmp|mp3|ogg|svg|swf|woff|woff2|eot|ttf|otf)$") {
+    if (req.url ~ "^/(pub/)?(media|static)/.*\.(ico|css|js|jpg|jpeg|png|gif|tiff|bmp|mp3|ogg|svg|swf|woff|woff2|eot|ttf|otf)$") {
         unset req.http.Https;
         unset req.http.X-Forwarded-Proto;
         unset req.http.Cookie;

--- a/templates/default/default.vcl.erb
+++ b/templates/default/default.vcl.erb
@@ -23,7 +23,7 @@ sub vcl_recv {
         if (!req.http.X-Magento-Tags-Pattern) {
             return (synth(400, "X-Magento-Tags-Pattern header required"));
         }
-        ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern);
+        ban("req.http.host ~ .*");
         return (synth(200, "Purged"));
     }
 

--- a/templates/default/default.vcl.erb
+++ b/templates/default/default.vcl.erb
@@ -48,6 +48,11 @@ sub vcl_recv {
         return (pass);
     }
 
+    # Check for bypass cookie
+    if (req.http.Cookie ~ "<% node['varnish']['bypass_cookie'] %>") {
+        return (pass);
+    }
+
 <% node['varnish']['bypass_urls'].each do |name,url| -%>
     # Bypass <%= name %> at "<%= url %>"
     if (req.url ~ "<%= url %>") {


### PR DESCRIPTION
* Sets attribute for `node['varnish']['bypass_cookie']`
* Varnish listens for for this cookie and bypasses caching when present
* Implements _aggressive_ cache banning on purge request.
* Whitespace formatting