### PR TITLE
Feature/first byte timeout

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,6 +15,7 @@ default['varnish']['frontend']['port'] = '80'
 # set this to point to your content server
 default['varnish']['backend']['ip']   = '127.0.0.1'
 default['varnish']['backend']['port'] = '8080'
+default['varnish']['backend']['first_byte_timeout'] = '60s'
 
 default['varnish']['admin']['ip']   = '127.0.0.1'
 default['varnish']['admin']['port'] = '6082'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
 description 'Installs and configures varnish.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.0.1'
+version '3.0.2'
 
 source_url 'https://github.com/copious-cookbooks/varnish'
 issues_url 'https://github.com/copious-cookbooks/varnish/issues'

--- a/templates/default/default.vcl.erb
+++ b/templates/default/default.vcl.erb
@@ -7,6 +7,7 @@ import std;
 backend default {
     .host = "<%= node['varnish']['backend']['ip'] %>";
     .port = "<%= node['varnish']['backend']['port'] %>";
+    .first_byte_timeout = "<%= node['varnish']['backend']['first_byte_timeout'] %>";
 }
 
 acl purge {


### PR DESCRIPTION
Adds first byte timeout attribute which can help avoid timeouts when paired with nginx proxy_read_timeout.

http://devdocs.magento.com/guides/v2.1/config-guide/varnish/config-varnish.html
https://magento.stackexchange.com/questions/161044/what-settings-are-needed-to-prevent-504-gateway-time-out-when-deleting-all-produ